### PR TITLE
Fix vision messages

### DIFF
--- a/vision.proto
+++ b/vision.proto
@@ -4,6 +4,7 @@ syntax = "proto3";
 
 import "geometry.proto";
 import "video.proto";
+import "version.proto";
 
 enum DetectedObjectType {
 	DETECTION_TYPE_UNDEFINED = 0;
@@ -13,25 +14,33 @@ enum DetectedObjectType {
 }
 
 message PnpResult {
-  Pose3d pose = 1;
-  double error = 2;
+  Pose3d cameraToTarget = 1;
+  double reprojectionError = 2;
 }
 
 message DetectedObject {
   // What was detected
   DetectedObjectType objectType = 1;
   int32 arucoTagId = 2;
-  CameraName camera = 3;
 
   // Where it was detected
   float xPosition = 4;  // -1 to +1 (left to right)
   float relativeSize = 5;  // 0 to 1 (percent of frame)
 
-  // Experimental: Use pinhole model to find the object's position
-  float yaw = 6;
-  float pitch = 7;
+  int32 centerX = 6;
+  int32 centerY = 7;
+
+  // Experimental: Use pinhole camera model to find the object's position
+  float yaw = 8;
+  float pitch = 9;
 
   // Experimental: Use PnP to determine the 3D pose
-  PnpResult bestPnpResult = 8;
-  PnpResult alternatePnpResult = 9;
+  PnpResult bestPnpResult = 10;
+  PnpResult alternatePnpResult = 11;
+}
+
+message VisionResult {
+  Version version = 1;
+  CameraName name = 2;
+  repeated DetectedObject objects = 3;
 }

--- a/vision.proto
+++ b/vision.proto
@@ -36,9 +36,3 @@ message DetectedObject {
   PnpResult bestPnpResult = 10;
   PnpResult alternatePnpResult = 11;
 }
-
-message VisionResult {
-  Version version = 1;
-  CameraName name = 2;
-  repeated DetectedObject objects = 3;
-}


### PR DESCRIPTION
- The message didn't account for one camera being able to detect multiple targets per frame
- CenterX and CenterY is necessary for mallet detection

Please don't delete random fields, some of those were there so the message can be reused for the mallet