### PR TITLE
Drive science cleanup

### DIFF
--- a/drive.proto
+++ b/drive.proto
@@ -39,7 +39,6 @@ message DriveCommand {
 	float rear_tilt = 10;
 
 	RoverStatus status = 11;
-	Version version = 12;
 	ProtoColor color = 13;
 	BoolState blink = 14;
 }
@@ -73,16 +72,8 @@ message DriveData {
 	float battery_current = 12;
 	float battery_temperature = 13;
 
+	bool has_version;
 	Version version = 14;
-
-	// Information about each wheel in rpm
-	float back_left = 15;
-	float middle_left = 16;
-	float front_left = 17;
-
-	float back_right = 18;
-	float middle_right = 19;
-	float front_right = 20;
 
 	ProtoColor color = 21;
 	RoverStatus status = 22;

--- a/science.proto
+++ b/science.proto
@@ -55,8 +55,6 @@ message ScienceCommand {
 	bool stop = 9;
 	int32 sample = 10;
 	ScienceState state = 11;
-
-	Version version = 12;
 }
 
 /// Data coming from the science subsystem.
@@ -69,6 +67,4 @@ message ScienceData {
 	float co2 = 3;
 	float humidity = 4;
 	float temperature = 5;
-	
-	Version version = 6;
 }


### PR DESCRIPTION
I cleaned up science.proto and drive.proto. I compared the respective .ino files, the .pb.h files, and other files for references to the variables in the .proto files. 

Science.proto:
- Removed version variables from ScienceCommand and ScienceData since I found no references to them

Drive.proto:
- Removed version variable from DriveCommand since no references were found
- Removed rpm variables from DriveData since no references were found
- Added has_version variable to DriveData since drive.ino uses it